### PR TITLE
Fixing non-virtual destructors in classes with virtual functions

### DIFF
--- a/Rx/v2/src/rxcpp/rx-observer.hpp
+++ b/Rx/v2/src/rxcpp/rx-observer.hpp
@@ -143,6 +143,7 @@ private:
 
     struct virtual_observer : public std::enable_shared_from_this<virtual_observer>
     {
+        virtual ~virtual_observer() {}
         virtual void on_next(T) const {};
         virtual void on_error(std::exception_ptr) const {};
         virtual void on_completed() const {};

--- a/Rx/v2/src/rxcpp/rx-subscription.hpp
+++ b/Rx/v2/src/rxcpp/rx-subscription.hpp
@@ -75,6 +75,7 @@ class subscription : public subscription_base
             : issubscribed(initial)
         {
         }
+        virtual ~base_subscription_state() {}
         virtual void unsubscribe() {
         }
         std::atomic<bool> issubscribed;

--- a/Rx/v2/src/rxcpp/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/rx-test.hpp
@@ -18,6 +18,7 @@ struct test_subject_base
     typedef rxn::recorded<typename rxn::notification<T>::type> recorded_type;
     typedef std::shared_ptr<test_subject_base<T>> type;
 
+    virtual ~test_subject_base() {}
     virtual void on_subscribe(subscriber<T>) const =0;
     virtual std::vector<recorded_type> messages() const =0;
     virtual std::vector<rxn::subscription> subscriptions() const =0;

--- a/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
+++ b/Rx/v2/src/rxcpp/schedulers/rx-test.hpp
@@ -309,6 +309,8 @@ public:
         }
     }
 
+    virtual ~hot_observable() {}
+
     virtual void on_subscribe(observer_type o) const {
         observers.push_back(o);
         sv.push_back(rxn::subscription(sc->clock()));


### PR DESCRIPTION
Fix for gcc compilation error "class has virtual functions and accessible non-virtual destructor".
