### PR TITLE
Fixing two issues of memory usage after free...

### DIFF
--- a/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-subject.hpp
@@ -155,10 +155,12 @@ public:
             b->current_generation = b->state->generation;
             b->current_completer = b->completer;
         }
-        if (!b->current_completer || b->current_completer->observers.empty()) {
+
+        auto current_completer = b->current_completer;
+        if (!current_completer || current_completer->observers.empty()) {
             return;
         }
-        for (auto& o : b->current_completer->observers) {
+        for (auto& o : current_completer->observers) {
             if (o.is_subscribed()) {
                 o.on_next(v);
             }
@@ -236,7 +238,7 @@ public:
     observable<T> get_observable() const {
         auto keepAlive = s;
         return make_observable_dynamic<T>([=](subscriber<T> o){
-            keepAlive.add(s.get_subscriber(), std::move(o));
+            keepAlive.add(keepAlive.get_subscriber(), std::move(o));
         });
     }
 };

--- a/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
+++ b/Rx/v2/src/rxcpp/subjects/rx-synchronize.hpp
@@ -182,7 +182,7 @@ public:
     observable<T> get_observable() const {
         auto keepAlive = s;
         return make_observable_dynamic<T>([=](subscriber<T> o){
-            keepAlive.add(s.get_subscriber(), std::move(o));
+            keepAlive.add(keepAlive.get_subscriber(), std::move(o));
         });
     }
 };


### PR DESCRIPTION
1) Using member variable instead of locally captured variable in lambda.  Causes problem when the enclosing instance is destroyed.
2) Race condition that causes 'current_completer' to be reset and observer list to be emptied while another thread is iterating through the observers in on_next.
